### PR TITLE
Enable multi-arch docker builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ aws/
 *.out
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
+vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN go mod download
 COPY cmd cmd
 COPY pkg pkg
 
-RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /mrfparse 
+RUN go build -ldflags="-w -s" -o /mrfparse
 
 FROM debian:bullseye-slim as runtime
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ all: build
 ## Build:
 build: ## Build your project
 	mkdir -p ./out/bin
-	GO111MODULE=on GOOS=linux GOARCH=amd64 $(GOCMD) build -o ./out/bin/$(BINARY_NAME) 
+	GO111MODULE=on $(GOCMD) build -o ./out/bin/$(BINARY_NAME)
 
 clean: ## Remove build related file
 	rm -f $(BINARY_NAME)


### PR DESCRIPTION
Hi there, me again :)

Another thing that would help adoption is to remove the hard-coded requirement of `amd64` (and `linux`), when building the binary either on-host or in-container.

As a quick example, I removed the `GOOS` and `GOARCH` vars from the dockerfile, then subsequently built and pushed this image to my public dockerhub here: https://hub.docker.com/r/dancarbone/danielchalef-mrfparse/tags

You can see that there are two images present for this tag, one arm64, one amd64.  This was done using the modified Dockerfile in this PR and the following command:

```shell
docker buildx build --platform linux/arm64,linux/amd64 -t dancarbone/danielchalef-mrfparse --push .
```

Proof of function:

```shell
$ docker run -it --entrypoint bash --platform linux/arm64 dancarbone/danielchalef-mrfparse -c 'uname -m'
aarch64
$
$ docker run -it --platform linux/arm64 dancarbone/danielchalef-mrfparse help  
MRFParse is a Go parser for Transparency in Coverage Machine Readable Format (MRF) files. 
        
The parser is designed to be memory and CPU efficient, and easily containerized. It will run on any modern cloud container platform (and potentially cloud function infrastructure).

Input and Output paths can be local filesytem paths or AWS S3 and Google Cloud Storage paths.

Usage:
  mrfparse [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  parse       Parse in-network MRF files. Expects split NDJSON files as input.
  pipeline    Parse in-network MRF files. Input is a single MRF JSON file. Output is a parquet fileset.
  split       Split JSON files.

Flags:
      --config string       config file (default config.yaml)
      --cpuprofile string   Write CPU profile to this file
  -h, --help                help for mrfparse
      --memprofile string   Write memory profile to this file

Use "mrfparse [command] --help" for more information about a command. 
```

Enabling multi-arch builds would let the ARM users on my team run this locally without the need to build it themselves, let alone have golang installed :)