### PR TITLE
Move pipeline download to discrete step

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,6 +87,7 @@ require (
 require (
 	github.com/alecthomas/assert/v2 v2.1.0
 	github.com/alitto/pond v1.8.2
+	github.com/avast/retry-go/v4 v4.3.2
 	github.com/rs/xid v1.4.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,8 @@ github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
+github.com/avast/retry-go/v4 v4.3.2 h1:x4sTEu3jSwr7zNjya8NTdIN+U88u/jtO/q3OupBoDtM=
+github.com/avast/retry-go/v4 v4.3.2/go.mod h1:rg6XFaiuFYII0Xu3RDbZQkxCofFwruZKW8oEF1jpWiU=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.15.27/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=

--- a/pkg/mrfparse/http/http.go
+++ b/pkg/mrfparse/http/http.go
@@ -1,0 +1,72 @@
+/*
+Copyright © 2023 Daniel Chalef
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package http
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/avast/retry-go/v4"
+	"github.com/danielchalef/mrfparse/pkg/mrfparse/utils"
+
+	"time"
+)
+
+const MaxRetryAttempts = 10
+const HTTPTimeOut = 2 * time.Minute
+
+var log = utils.GetLogger()
+
+var httpClient = &http.Client{
+	Timeout: HTTPTimeOut,
+}
+
+// DownloadFileReader downloads a file from the given URL and returns an io.ReadCloser.
+// The caller is responsible for closing the returned io.ReadCloser.
+// DownloadFilereader attempts to retry the download if it receives a RetryAfterDelay error.
+func DownloadReader(fileURL string) (io.ReadCloser, error) {
+	var (
+		err error
+		r   *http.Response
+	)
+
+	err = retry.Do(func() error {
+		r, err = httpClient.Get(fileURL) //nolint:bodyclose // Embedded in retry confusing linter
+		if err != nil {
+			r.Body.Close()
+			return err
+		}
+		return nil
+	}, retry.DelayType(RetryAfterDelay),
+		retry.Attempts(MaxRetryAttempts),
+	)
+	if err != nil {
+		r.Body.Close()
+
+		return nil, fmt.Errorf("unable to download file from %s: %s", fileURL, errors.Unwrap(err))
+	}
+
+	if r.StatusCode != http.StatusOK {
+		errorText := fmt.Errorf("bad status downloading %s: %s", fileURL, r.Status)
+		log.Error(errorText)
+
+		return nil, errorText
+	}
+
+	return r.Body, nil
+}

--- a/pkg/mrfparse/http/http_retry_after.go
+++ b/pkg/mrfparse/http/http_retry_after.go
@@ -1,0 +1,117 @@
+/*
+MIT License
+
+# Copyright (c) 2020 aereal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+package http
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/avast/retry-go/v4"
+)
+
+var (
+	// ErrNegativeSecondsNotAllowed is parsing error that represents seconds value is negative.
+	// The seconds value in Retry-After must be positive.
+	ErrNegativeSecondsNotAllowed = errors.New("negative seconds not allowed")
+
+	// ErrInvalidFormat is parsing error that represents given Retry-After neither valid seconds nor valid HTTP date.
+	ErrInvalidFormat = errors.New("Retry-After value must be seconds integer or HTTP date string")
+)
+
+func RetryAfterDelay(n uint, err error, config *retry.Config) time.Duration {
+	var (
+		t time.Time
+		e *RetryAfterError
+	)
+
+	if errors.As(err, e) {
+		if t, err = ParseRetryAfter(e.response.Header.Get("Retry-After")); err == nil {
+			log.Warnf("Got Retry-After header: %s", t)
+			return time.Until(t)
+		}
+	}
+
+	delay := retry.BackOffDelay(n, err, config)
+
+	if n > MaxRetryAttempts/2 {
+		log.Warnf("Retrying in %s after error %s", delay, err)
+	}
+
+	return delay
+}
+
+type RetryAfterError struct {
+	response http.Response
+}
+
+func (err RetryAfterError) Error() string {
+	return fmt.Sprintf(
+		"Request to %s fail %s (%d)",
+		err.response.Request.RequestURI,
+		err.response.Status,
+		err.response.StatusCode,
+	)
+}
+
+// Parse tries to parse the value as seconds or HTTP date.
+func ParseRetryAfter(retryAfter string) (time.Time, error) {
+	if dur, err := ParseSeconds(retryAfter); err == nil {
+		now := time.Now()
+		return now.Add(dur), nil
+	}
+
+	if dt, err := ParseHTTPDate(retryAfter); err == nil {
+		return dt, nil
+	}
+
+	return time.Time{}, ErrInvalidFormat
+}
+
+// ParseSeconds parses the value as seconds.
+func ParseSeconds(retryAfter string) (time.Duration, error) {
+	seconds, err := strconv.ParseInt(retryAfter, 10, 64)
+
+	if err != nil {
+		return time.Duration(0), err
+	}
+
+	if seconds < 0 {
+		return time.Duration(0), ErrNegativeSecondsNotAllowed
+	}
+
+	return time.Second * time.Duration(seconds), nil
+}
+
+// ParseHTTPDate parses the value as HTTP date.
+func ParseHTTPDate(retryAfter string) (time.Time, error) {
+	parsed, err := time.Parse(time.RFC1123, retryAfter)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	return parsed, nil
+}

--- a/pkg/mrfparse/http/http_retry_after_test.go
+++ b/pkg/mrfparse/http/http_retry_after_test.go
@@ -1,0 +1,115 @@
+/*
+MIT License
+
+# Copyright (c) 2020 aereal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+package http
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestParseSeconds(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"ok", "60", time.Minute * 1, false},
+		{"invalid", "", time.Duration(0), true},
+		{"negative", "-10", time.Duration(0), true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := ParseSeconds(c.args)
+			if (err != nil) != c.wantErr {
+				t.Errorf("error = %v, wantErr %v", err, c.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("got = %v, want = %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestParseHTTPDate(t *testing.T) {
+	now := time.Now()
+	// orig := nowFunc
+	// nowFunc = func() time.Time { return now }
+	// defer func() {
+	// 	nowFunc = orig
+	// }()
+	aMinuteLater := now.Add(time.Minute)
+
+	cases := []struct {
+		name    string
+		args    string
+		want    time.Time
+		wantErr bool
+	}{
+		{"ok", aMinuteLater.Format(time.RFC1123), aMinuteLater, false},
+		{"invalid format", "2020-01-02", time.Time{}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := ParseHTTPDate(c.args)
+			if (err != nil) != c.wantErr {
+				t.Errorf("error = %v, wantErr %v", err, c.wantErr)
+				return
+			}
+			if got.Unix() != c.want.Unix() {
+				t.Errorf("got = %s, want %s", got, c.want)
+			}
+		})
+	}
+}
+
+func TestParse(t *testing.T) {
+	now := time.Now()
+	aMinuteLater := now.Add(time.Minute)
+
+	cases := []struct {
+		name    string
+		args    string
+		want    time.Time
+		wantErr bool
+	}{
+		{"seconds/ok", "60", aMinuteLater, false},
+		{"http date/ok", aMinuteLater.Format(time.RFC1123), aMinuteLater, false},
+		{"invalid", "", time.Time{}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := ParseRetryAfter(c.args)
+			if (err != nil) != c.wantErr {
+				t.Errorf("error = %v, wantErr %v", err, c.wantErr)
+				return
+			}
+			if got.Unix() != c.want.Unix() {
+				t.Errorf("got = %s, want %s", got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Moved pieline download to discrete step rather than use  to download using `jsplit`. This ensures we don't have a long running HTTP connection open at risk of timing out