### PR TITLE
check scanner.Err(), allow scanner buffer to grow

### DIFF
--- a/pkg/mrfparse/mrf/parse.go
+++ b/pkg/mrfparse/mrf/parse.go
@@ -33,7 +33,9 @@ import (
 const MaxWorkers int = 5
 const MaxCapacity int = 4
 
-const MaxLineLength int = 5000000 // bytes
+const LineBuffer int = 5000000           // bytes
+const MaxLineBuffer int = LineBuffer * 5 // bytes
+
 type StringSet mapset.Set[string]
 
 var log = utils.GetLogger()

--- a/pkg/mrfparse/mrf/provider_references.go
+++ b/pkg/mrfparse/mrf/provider_references.go
@@ -19,12 +19,13 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"github.com/danielchalef/mrfparse/pkg/mrfparse/cloud"
-	"github.com/danielchalef/mrfparse/pkg/mrfparse/models"
-	"github.com/danielchalef/mrfparse/pkg/mrfparse/utils"
 	"io"
 	"strings"
 	"sync/atomic"
+
+	"github.com/danielchalef/mrfparse/pkg/mrfparse/cloud"
+	"github.com/danielchalef/mrfparse/pkg/mrfparse/models"
+	"github.com/danielchalef/mrfparse/pkg/mrfparse/utils"
 
 	"github.com/minio/simdjson-go"
 )
@@ -57,8 +58,8 @@ func parseProviderReference(filename, rootUUID string) {
 
 	scanner := bufio.NewScanner(f)
 
-	buf := make([]byte, MaxLineLength)
-	scanner.Buffer(buf, MaxLineLength)
+	buf := make([]byte, LineBuffer)
+	scanner.Buffer(buf, MaxLineBuffer)
 
 	for scanner.Scan() {
 		// Build a NDJSON string with LinesAtATime lines
@@ -86,6 +87,10 @@ func parseProviderReference(filename, rootUUID string) {
 		}
 
 		totalLineCount++
+	}
+
+	if err := scanner.Err(); err != nil {
+		utils.ExitOnError(err)
 	}
 
 	// Ensure we parse the last few lines if we've not yet reached LinesAtATime


### PR DESCRIPTION
Very large in_network_rates objects were overflowing the scanner buffer. `scanner.Err()` was not being checked, resulting in skipped lines with no errors.
- Check `scanner.Err()`
- Allow scanner buffer to grow to `MaxLineBuffer`, which is 5x `LineBuffer`